### PR TITLE
Update Docker image name in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,5 +23,5 @@ then
   exit 1
 fi
 
-docker build -t ides-server:$IDES_SERVER_VERSION .
+docker build -t tbe-server:$IDES_SERVER_VERSION .
 ```


### PR DESCRIPTION
The Docker image name in the Readme file has been updated from "ides-server" to "tbe-server". This change reflects the updated name of the server image. Follow up at https://github.com/JetBrains/toolbox-enterprise-docker/pull/4#discussion_r1565595467